### PR TITLE
feat: implement Quick Saves board system

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import { RestaurantCardWithSave } from '@/components/cards/RestaurantCardWithSav
 import { ErrorState } from '@/components/ErrorState';
 import { NotificationBadge } from '@/components/NotificationBadge';
 import { NotificationCenter } from '@/components/NotificationCenter';
+import QuickSavesBoard from '@/components/home/QuickSavesBoard';
 import { applyShadow, designTokens } from '@/constants/designTokens';
 import { theme } from '@/constants/theme';
 import { useApp } from '@/contexts/AppContext';
@@ -509,6 +510,8 @@ export default function HomeScreen() {
         {userState.isNewUser && renderWelcomeBanner()}
         
         {userState.friendsCount < 5 && renderNetworkBuilding()}
+        
+        {user && <QuickSavesBoard />}
         
         {renderYourBoards()}
         

--- a/app/quick-saves.tsx
+++ b/app/quick-saves.tsx
@@ -1,0 +1,318 @@
+import React, { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  ActivityIndicator,
+  TouchableOpacity,
+  SafeAreaView,
+  RefreshControl
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import { ArrowLeft } from 'lucide-react-native'
+import { useAuth } from '@/contexts/AuthContext'
+import { boardService } from '@/services/boardService'
+import { restaurantService } from '@/services/restaurantService'
+import { BoardRestaurant } from '@/types/board'
+import { RestaurantInfo } from '@/types/core'
+import { RestaurantCard } from '@/components/cards/RestaurantCard'
+import { theme } from '@/constants/theme'
+import { designTokens } from '@/constants/designTokens'
+
+type QuickSave = BoardRestaurant & { restaurant?: RestaurantInfo }
+
+export default function QuickSavesScreen() {
+  const [saves, setSaves] = useState<QuickSave[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    loadQuickSaves()
+  }, [user?.id])
+
+  const loadQuickSaves = async () => {
+    if (!user?.id) return
+
+    try {
+      setError(null)
+      
+      // Get all Quick Saves (no limit)
+      const quickSaves = await boardService.getQuickSavesRestaurants(user.id)
+      
+      // Load restaurant details for each save
+      const savesWithRestaurants = await Promise.all(
+        quickSaves.map(async (save) => {
+          const restaurant = await restaurantService.getRestaurantById(save.restaurant_id)
+          return {
+            ...save,
+            restaurant: restaurant || undefined
+          }
+        })
+      )
+
+      setSaves(savesWithRestaurants.filter(save => save.restaurant))
+    } catch (error) {
+      console.error('Error loading quick saves:', error)
+      setError('Failed to load saved restaurants')
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }
+
+  const onRefresh = async () => {
+    setRefreshing(true)
+    await loadQuickSaves()
+  }
+
+  const handleRestaurantPress = (restaurantId: string) => {
+    router.push(`/restaurant/${restaurantId}`)
+  }
+
+  const handleRemove = async (save: QuickSave) => {
+    try {
+      // Get the Quick Saves board
+      const board = await boardService.getUserQuickSavesBoard(user!.id)
+      if (board) {
+        await boardService.removeRestaurantFromBoard(board.id, save.restaurant_id)
+        // Refresh the list
+        await loadQuickSaves()
+      }
+    } catch (error) {
+      console.error('Error removing from Quick Saves:', error)
+    }
+  }
+
+  const renderHeader = () => (
+    <View style={styles.header}>
+      <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+        <ArrowLeft size={24} color={designTokens.colors.textDark} />
+      </TouchableOpacity>
+      <Text style={styles.headerTitle}>Quick Saves</Text>
+      <View style={styles.placeholder} />
+    </View>
+  )
+
+  const renderRestaurant = ({ item }: { item: QuickSave }) => {
+    if (!item.restaurant) return null
+
+    return (
+      <View style={styles.saveItem}>
+        <RestaurantCard
+          restaurant={item.restaurant}
+          onPress={() => handleRestaurantPress(item.restaurant_id)}
+        />
+        {item.notes && (
+          <Text style={styles.notes}>{item.notes}</Text>
+        )}
+        <View style={styles.metadata}>
+          <Text style={styles.savedDate}>
+            Saved {new Date(item.added_at).toLocaleDateString()}
+          </Text>
+          <TouchableOpacity
+            onPress={() => handleRemove(item)}
+            style={styles.removeButton}
+          >
+            <Text style={styles.removeText}>Remove</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    )
+  }
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        {renderHeader()}
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <Text style={styles.loadingText}>Loading your saved restaurants...</Text>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container}>
+        {renderHeader()}
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={loadQuickSaves}>
+            <Text style={styles.retryText}>Try Again</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {renderHeader()}
+      
+      {saves.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyTitle}>No Quick Saves Yet</Text>
+          <Text style={styles.emptyText}>
+            Tap the save button on any restaurant to add it to your Quick Saves
+          </Text>
+          <TouchableOpacity 
+            style={styles.exploreButton}
+            onPress={() => router.push('/explore')}
+          >
+            <Text style={styles.exploreButtonText}>Explore Restaurants</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={saves}
+          renderItem={renderRestaurant}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={theme.colors.primary}
+            />
+          }
+          ListHeaderComponent={
+            <Text style={styles.countText}>
+              {saves.length} saved {saves.length === 1 ? 'restaurant' : 'restaurants'}
+            </Text>
+          }
+        />
+      )}
+    </SafeAreaView>
+  )
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  header: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    justifyContent: 'space-between' as const,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: designTokens.colors.borderLight,
+  },
+  backButton: {
+    padding: theme.spacing.xs,
+  },
+  headerTitle: {
+    ...designTokens.typography.sectionTitle,
+    color: theme.colors.text.primary,
+  },
+  placeholder: {
+    width: 32,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+  },
+  loadingText: {
+    ...designTokens.typography.bodyRegular,
+    color: theme.colors.text.secondary,
+    marginTop: theme.spacing.md,
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+    paddingHorizontal: theme.spacing.xl,
+  },
+  errorText: {
+    ...designTokens.typography.bodyRegular,
+    color: theme.colors.error,
+    textAlign: 'center' as const,
+    marginBottom: theme.spacing.lg,
+  },
+  retryButton: {
+    backgroundColor: theme.colors.primary,
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.md,
+    borderRadius: 8,
+  },
+  retryText: {
+    ...designTokens.typography.bodyMedium,
+    color: '#FFFFFF',
+    fontWeight: '600' as const,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+    paddingHorizontal: theme.spacing.xl,
+  },
+  emptyTitle: {
+    ...designTokens.typography.cardTitle,
+    color: theme.colors.text.primary,
+    marginBottom: theme.spacing.sm,
+  },
+  emptyText: {
+    ...designTokens.typography.bodyRegular,
+    color: theme.colors.text.secondary,
+    textAlign: 'center' as const,
+    marginBottom: theme.spacing.xl,
+  },
+  exploreButton: {
+    backgroundColor: theme.colors.primary,
+    paddingHorizontal: theme.spacing.xl,
+    paddingVertical: theme.spacing.md,
+    borderRadius: 24,
+  },
+  exploreButtonText: {
+    ...designTokens.typography.bodyMedium,
+    color: '#FFFFFF',
+    fontWeight: '600' as const,
+  },
+  listContent: {
+    paddingVertical: theme.spacing.md,
+  },
+  countText: {
+    ...designTokens.typography.detailText,
+    color: theme.colors.text.secondary,
+    paddingHorizontal: theme.spacing.md,
+    paddingBottom: theme.spacing.md,
+  },
+  saveItem: {
+    paddingHorizontal: theme.spacing.md,
+    marginBottom: theme.spacing.lg,
+  },
+  notes: {
+    ...designTokens.typography.bodyRegular,
+    color: theme.colors.text.secondary,
+    marginTop: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.sm,
+  },
+  metadata: {
+    flexDirection: 'row' as const,
+    justifyContent: 'space-between' as const,
+    alignItems: 'center' as const,
+    marginTop: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.sm,
+  },
+  savedDate: {
+    ...designTokens.typography.detailText,
+    color: theme.colors.text.tertiary,
+  },
+  removeButton: {
+    paddingVertical: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.sm,
+  },
+  removeText: {
+    ...designTokens.typography.detailText,
+    color: theme.colors.error,
+    fontWeight: '600' as const,
+  },
+}

--- a/components/home/QuickSavesBoard.tsx
+++ b/components/home/QuickSavesBoard.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useState } from 'react'
+import { View, Text, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useAuth } from '@/contexts/AuthContext'
+import { boardService } from '@/services/boardService'
+import { restaurantService } from '@/services/restaurantService'
+import { BoardRestaurant } from '@/types/board'
+import { RestaurantInfo } from '@/types/core'
+import { RestaurantCard } from '@/components/cards/RestaurantCard'
+import { theme } from '@/constants/theme'
+import { designTokens } from '@/constants/designTokens'
+
+interface QuickSavesBoardProps {
+  onRestaurantPress?: (restaurantId: string) => void
+}
+
+const QuickSavesBoard: React.FC<QuickSavesBoardProps> = ({ onRestaurantPress }) => {
+  const [saves, setSaves] = useState<Array<BoardRestaurant & { restaurant?: RestaurantInfo }>>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    loadQuickSaves()
+  }, [user?.id])
+
+  const loadQuickSaves = async () => {
+    if (!user?.id) return
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      // Get Quick Saves restaurants
+      const quickSaves = await boardService.getQuickSavesRestaurants(user.id, 10)
+      
+      // Load restaurant details for each save
+      const savesWithRestaurants = await Promise.all(
+        quickSaves.map(async (save) => {
+          const restaurant = await restaurantService.getRestaurantById(save.restaurant_id)
+          return {
+            ...save,
+            restaurant: restaurant || undefined
+          }
+        })
+      )
+
+      setSaves(savesWithRestaurants.filter(save => save.restaurant))
+    } catch (error) {
+      console.error('Error loading quick saves:', error)
+      setError('Failed to load saved restaurants')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleRestaurantPress = (restaurantId: string) => {
+    if (onRestaurantPress) {
+      onRestaurantPress(restaurantId)
+    } else {
+      router.push(`/restaurant/${restaurantId}`)
+    }
+  }
+
+  const handleViewAll = () => {
+    router.push('/quick-saves')
+  }
+
+  if (!user) return null
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Quick Saves</Text>
+        </View>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="small" color={theme.colors.primary} />
+        </View>
+      </View>
+    )
+  }
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Quick Saves</Text>
+        </View>
+        <Text style={styles.errorText}>{error}</Text>
+      </View>
+    )
+  }
+
+  if (saves.length === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Quick Saves</Text>
+        </View>
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyText}>No saved restaurants yet</Text>
+          <Text style={styles.emptySubtext}>Tap the save button on any restaurant to add it here</Text>
+        </View>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Quick Saves</Text>
+        <TouchableOpacity onPress={handleViewAll}>
+          <Text style={styles.viewAllText}>View All</Text>
+        </TouchableOpacity>
+      </View>
+      
+      <ScrollView 
+        horizontal 
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+      >
+        {saves.map((save) => (
+          save.restaurant && (
+            <View key={save.id} style={styles.restaurantCard}>
+              <RestaurantCard
+                restaurant={save.restaurant}
+                onPress={() => handleRestaurantPress(save.restaurant_id)}
+              />
+            </View>
+          )
+        ))}
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = {
+  container: {
+    marginVertical: theme.spacing.lg,
+  },
+  header: {
+    flexDirection: 'row' as const,
+    justifyContent: 'space-between' as const,
+    alignItems: 'center' as const,
+    paddingHorizontal: theme.spacing.md,
+    marginBottom: theme.spacing.md,
+  },
+  title: {
+    ...designTokens.typography.sectionTitle,
+    color: theme.colors.text.primary,
+  },
+  viewAllText: {
+    ...designTokens.typography.bodyMedium,
+    color: theme.colors.primary,
+    fontWeight: '600' as const,
+  },
+  scrollContent: {
+    paddingHorizontal: theme.spacing.md,
+  },
+  restaurantCard: {
+    marginRight: theme.spacing.md,
+    width: 280,
+  },
+  loadingContainer: {
+    height: 200,
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+  },
+  errorText: {
+    ...designTokens.typography.bodyRegular,
+    color: theme.colors.error,
+    textAlign: 'center' as const,
+    paddingHorizontal: theme.spacing.md,
+  },
+  emptyContainer: {
+    height: 150,
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+    paddingHorizontal: theme.spacing.xl,
+  },
+  emptyText: {
+    ...designTokens.typography.bodyRegular,
+    color: theme.colors.text.secondary,
+    textAlign: 'center' as const,
+    marginBottom: theme.spacing.xs,
+  },
+  emptySubtext: {
+    ...designTokens.typography.detailText,
+    color: theme.colors.text.tertiary,
+    textAlign: 'center' as const,
+  },
+}
+
+export default QuickSavesBoard

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -31,6 +31,21 @@ export const userService = {
       console.error('Error creating user profile:', error)
       return null
     }
+
+    // Ensure Quick Saves board is created for new user
+    if (data) {
+      try {
+        const { data: boardId } = await supabase
+          .rpc('ensure_quick_saves_board', { p_user_id: data.id })
+        
+        if (boardId) {
+          console.log('Quick Saves board created:', boardId)
+        }
+      } catch (error) {
+        console.error('Error creating Quick Saves board:', error)
+      }
+    }
+
     return data
   },
 
@@ -170,6 +185,17 @@ export const userService = {
     if (error) {
       console.error('Error searching users:', error)
       return []
+    }
+    return data
+  },
+
+  async getQuickSavesBoard(userId: string): Promise<string | null> {
+    const { data, error } = await supabase
+      .rpc('get_quick_saves_board', { p_user_id: userId })
+    
+    if (error) {
+      console.error('Error getting Quick Saves board:', error)
+      return null
     }
     return data
   }

--- a/supabase/migrations/20250125_quick_saves_board.sql
+++ b/supabase/migrations/20250125_quick_saves_board.sql
@@ -1,0 +1,127 @@
+-- Migration: Quick Saves Board System
+-- Description: Implements default Quick Saves board for all users
+-- Author: Claude
+-- Date: 2025-01-25
+
+-- 1. Add default_board_id to users table
+ALTER TABLE users 
+ADD COLUMN IF NOT EXISTS default_board_id UUID REFERENCES boards(id);
+
+-- 2. Create function to ensure Quick Saves board exists
+CREATE OR REPLACE FUNCTION ensure_quick_saves_board(p_user_id uuid)
+RETURNS uuid AS $$
+DECLARE
+  v_board_id uuid;
+BEGIN
+  -- Check if Quick Saves board exists
+  SELECT id INTO v_board_id 
+  FROM boards 
+  WHERE user_id = p_user_id AND title = 'Quick Saves' AND type = 'free';
+  
+  -- Create if doesn't exist
+  IF v_board_id IS NULL THEN
+    INSERT INTO boards (user_id, title, description, type, is_private, allow_comments, allow_saves)
+    VALUES (
+      p_user_id, 
+      'Quick Saves', 
+      'Your default collection of saved restaurants', 
+      'free',
+      true,  -- Quick Saves board is private by default
+      false, -- No comments on Quick Saves
+      false  -- Others can't save from Quick Saves
+    )
+    RETURNING id INTO v_board_id;
+    
+    -- Add user as owner in board_members
+    INSERT INTO board_members (board_id, user_id, role)
+    VALUES (v_board_id, p_user_id, 'owner')
+    ON CONFLICT (board_id, user_id) DO NOTHING;
+  END IF;
+  
+  -- Update user's default board
+  UPDATE users SET default_board_id = v_board_id WHERE id = p_user_id;
+  
+  RETURN v_board_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 3. Create function to get or create user's Quick Saves board
+CREATE OR REPLACE FUNCTION get_quick_saves_board(p_user_id uuid)
+RETURNS uuid AS $$
+DECLARE
+  v_board_id uuid;
+BEGIN
+  -- Get user's default board
+  SELECT default_board_id INTO v_board_id FROM users WHERE id = p_user_id;
+  
+  -- If no default board, ensure Quick Saves exists
+  IF v_board_id IS NULL THEN
+    v_board_id := ensure_quick_saves_board(p_user_id);
+  END IF;
+  
+  RETURN v_board_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 4. Modify the create_default_board trigger to create Quick Saves board
+DROP TRIGGER IF EXISTS create_default_board_trigger ON auth.users;
+DROP FUNCTION IF EXISTS create_default_board();
+
+CREATE OR REPLACE FUNCTION create_quick_saves_on_signup()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_board_id uuid;
+BEGIN
+  -- Create user record in users table if not exists
+  INSERT INTO users (id)
+  VALUES (NEW.id)
+  ON CONFLICT (id) DO NOTHING;
+  
+  -- Create Quick Saves board
+  v_board_id := ensure_quick_saves_board(NEW.id);
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Create trigger to create Quick Saves board when a new user is created
+CREATE TRIGGER create_quick_saves_on_signup_trigger
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION create_quick_saves_on_signup();
+
+-- 5. Create or update existing users with Quick Saves boards
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN SELECT id FROM users WHERE default_board_id IS NULL
+  LOOP
+    PERFORM ensure_quick_saves_board(r.id);
+  END LOOP;
+END $$;
+
+-- 6. Create view for Quick Saves boards
+CREATE OR REPLACE VIEW quick_saves_boards AS
+SELECT 
+  b.*,
+  br.restaurant_count as saved_restaurants_count
+FROM boards b
+LEFT JOIN (
+  SELECT board_id, COUNT(*) as restaurant_count
+  FROM board_restaurants
+  GROUP BY board_id
+) br ON b.id = br.board_id
+WHERE b.title = 'Quick Saves' AND b.type = 'free';
+
+-- 7. Grant permissions
+GRANT EXECUTE ON FUNCTION ensure_quick_saves_board TO authenticated;
+GRANT EXECUTE ON FUNCTION get_quick_saves_board TO authenticated;
+GRANT SELECT ON quick_saves_boards TO authenticated;
+
+-- 8. Add RLS policy for Quick Saves visibility (users can only see their own)
+CREATE POLICY "Users can only view their own Quick Saves board" ON boards
+  FOR SELECT
+  USING (
+    title = 'Quick Saves' AND user_id = auth.uid()
+  );


### PR DESCRIPTION
- Add database migration for Quick Saves functionality
- Create automatic Quick Saves board for new users
- Update save flow to use Quick Saves as default destination
- Add Quick Saves tab to profile screen (set as default)
- Create QuickSavesBoard component for homepage display
- Add dedicated Quick Saves screen with pull-to-refresh
- Update BoardSelectionModal to show Quick Saves prominently
- Fix import paths and theme references
- Add auto-refresh when navigating back to profile

🤖 Generated with [Claude Code](https://claude.ai/code)